### PR TITLE
fix(grpc-xds): Fixes for Docker Desktop and zsh

### DIFF
--- a/grpc-xds/README.md
+++ b/grpc-xds/README.md
@@ -453,7 +453,7 @@ Some troubleshooting commands:
 - [gRFC A39: xDS HTTP Filter Support](https://github.com/grpc/proposal/blob/b2093bc96e045d7a13ccc01886b9dde346c2b83b/A39-xds-http-filters.md)
 - [gRFC A40: xDS Configuration Dump via Client Status Discovery Service in gRPC](https://github.com/grpc/proposal/blob/312af83e2f6af1ccb9b048b967635f67c8d40643/A40-csds-support.md)
 - [gRFC A41: xDS RBAC Support](https://github.com/grpc/proposal/blob/c83f0cb8ed534c4192e0e5d7a4550a1f5a76ef65/A41-xds-rbac.md)
-- [Envoy Role Based Access Control (RBAC) Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rbac_filter)
+- [Envoy Role Based Access Control (RBAC) HTTP Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rbac_filter)
 - [gRFC A42: xDS Ring Hash LB Policy](https://github.com/grpc/proposal/blob/1d50990f5e95d5d15233e35e56ac1dc33fcd56b3/A42-xds-ring-hash-lb-policy.md)
 - [gRFC A44: gRPC xDS Retry Support](https://github.com/grpc/proposal/blob/6b550edf7407047d423c8fa530e4f9d2e50a2fd2/A44-xds-retry.md)
 - [gRFC A47: xDS Federation](https://github.com/grpc/proposal/blob/e85c66e48348867937688d89117bad3dcaa6f4f5/A47-xds-federation.md)

--- a/grpc-xds/docs/kind.md
+++ b/grpc-xds/docs/kind.md
@@ -3,7 +3,7 @@
 [kind](https://kind.sigs.k8s.io/) is a command-line tool for running local
 Kubernetes clusters using [podman](https://podman.io/) or
 [Docker](https://www.docker.com/).
-kind is handy for development purposes if you don't have access to a hosted
+kind is useful for development purposes if you don't have access to a hosted
 Kubernetes cluster and container image registry.
 
 Follow the instructions below to create multi-node Kubernetes clusters using
@@ -12,6 +12,11 @@ Follow the instructions below to create multi-node Kubernetes clusters using
 for simulating clusters with nodes across multiple cloud provider zones, and
 with [cert-manager](https://cert-manager.io/docs/) and a root certificate
 authority (CA) to issue workload certificates for TLS and mTLS.
+
+## Install kind
+
+1.  Install kind by following the
+    [kind installation guide](https://kind.sigs.k8s.io/docs/user/quick-start#installation).
 
 ## Docker Desktop setup
 
@@ -30,6 +35,8 @@ authority (CA) to issue workload certificates for TLS and mTLS.
 ## Podman setup
 
 If you want to use kind with podman, follow the steps in this section.
+
+<style>ol ol { list-style-type: lower-alpha; }</style>
 
 1.  Increase the virtual machine CPU and memory allocation, so that the
     Kubernetes cluster(s) will have sufficient capacity.
@@ -72,7 +79,7 @@ If you want to use kind with podman, follow the steps in this section.
 
     On macOS, the output should look similar to this:
 
-    ```
+    ```shell
     /Users/$USER/.local/share/containers/podman/machine/podman.sock
     ```
 
@@ -127,7 +134,7 @@ You can view the kind cluster configuration files:
 
 ## Cleaning up
 
-1.  When you are done, delete the kind Kubernetes cluster
+1.  When you are done, delete the kind Kubernetes cluster(s).
 
     If you created two kind clusters, delete both:
 

--- a/grpc-xds/hack/kind-multi-cluster.sh
+++ b/grpc-xds/hack/kind-multi-cluster.sh
@@ -34,14 +34,7 @@ if [ "$KIND_EXPERIMENTAL_PROVIDER" == "podman" ] ; then
      echo "fs.inotify.max_user_watches=1048576" | sudo tee -a /etc/sysctl.conf > /dev/null &&
      echo "fs.inotify.max_user_instances=8192" | sudo tee -a /etc/sysctl.conf > /dev/null &&
      sudo sysctl -p /etc/sysctl.conf'
-elif [ "$(uname -s)" != "Linux" ] ; then
-  # Assuming Docker Desktop
-  docker run -it --privileged --pid=host debian:stable nsenter -t 1 -m -u -n -i sh -c \
-    'grep -v "fs.inotify.max_user_[instances|watches]" /etc/sysctl.conf | sudo tee /etc/sysctl.conf > /dev/null &&
-     echo "fs.inotify.max_user_watches=1048576" | sudo tee -a /etc/sysctl.conf > /dev/null &&
-     echo "fs.inotify.max_user_instances=8192" | sudo tee -a /etc/sysctl.conf > /dev/null &&
-     sudo sysctl -p /etc/sysctl.conf'
-else
+elif [ "$(uname -s)" == "Linux" ] ; then
   # In case of Docker Engine on a Linux host, don't just change the host.
   echo "******************************************************************************************
 * It looks like you are using Docker Engine on a machine running Linux.                  *


### PR DESCRIPTION
Fix the kind multi-cluster setup script by removing the block that tried to set inotify limits on the Docker Desktop VM. The default limits appear to be sufficient.

Update the GKE instructions for zsh users. The problem was that array indexes start at 0 with bash and at 1 with zsh.