### PR TITLE
Fix syntax error in kind-multi-cluster.sh

### DIFF
--- a/grpc-xds/hack/kind-multi-cluster.sh
+++ b/grpc-xds/hack/kind-multi-cluster.sh
@@ -28,12 +28,13 @@ pushd "$base_dir"
 # Workaround for
 # https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER:-}
-if [ "$KIND_EXPERIMENTAL_PROVIDER" == "podman" && "$(uname -s)" != "Linux" ] ; then
+if [[ "$KIND_EXPERIMENTAL_PROVIDER" == "podman" && "$(uname -s)" != "Linux" ]] ; then
   podman machine ssh \
     'grep -v "fs.inotify.max_user_[instances|watches]" /etc/sysctl.conf | sudo tee /etc/sysctl.conf > /dev/null &&
      echo "fs.inotify.max_user_watches=1048576" | sudo tee -a /etc/sysctl.conf > /dev/null &&
      echo "fs.inotify.max_user_instances=8192" | sudo tee -a /etc/sysctl.conf > /dev/null &&
      sudo sysctl -p /etc/sysctl.conf'
+fi
 if [ "$(uname -s)" == "Linux" ] ; then
   # In case of podman or Docker Engine on a Linux host, don't just change the host.
   echo "******************************************************************************************


### PR DESCRIPTION
I am getting the following syntax error when running the script in `zsh 5.9` or `bash 5.2` on Apple M1 Max (macOS 14.4.1 (23E224) / Darwin 23.4.0)

```bash
$ make kind-create-multi-cluster
./hack/kind-multi-cluster.sh
~/fun/solutions-workshops/grpc-xds ~/fun/solutions-workshops/grpc-xds
./hack/kind-multi-cluster.sh: line 144: syntax error: unexpected end of file
make: *** [kind-create-multi-cluster] Error 2
```

This PR fixes the issue.