### PR TITLE
doc(grpc-xds): Update Cloud Service Mesh links

### DIFF
--- a/grpc-xds/README.md
+++ b/grpc-xds/README.md
@@ -21,7 +21,8 @@ clusters, or on local [kind](https://kind.sigs.k8s.io/) Kubernetes clusters.
 
 The code in this repository in not recommended for production environments.
 If you want a production-ready xDS control plane, we recommend
-[Traffic Director](https://cloud.google.com/traffic-director/docs) from Google Cloud.
+[Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/service-routing/proxyless-overview)
+from Google Cloud.
 
 ## Directory structure
 
@@ -428,12 +429,14 @@ Some troubleshooting commands:
 
 ## xDS references
 
+- [On the state of Envoy Proxy control planes](https://mattklein123.dev/2020/03/15/2020-03-14-on-the-state-of-envoy-proxy-control-planes/)
 - [xDS API Overview](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/overview)
 - [xDS REST and gRPC protocol](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol)
+- [xDS Features in gRPC](https://github.com/grpc/grpc/blob/1b31c6e0ba711787c05e8e78719896a682fca102/doc/grpc_xds_features.md)
 - [Aggregated Discovery Service (ADS)](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/xds_api#aggregated-discovery-service)
 - [Load Reporting Service (LRS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/load_stats/v3/lrs.proto)
-- [On the state of Envoy Proxy control planes](https://mattklein123.dev/2020/03/15/2020-03-14-on-the-state-of-envoy-proxy-control-planes/)
-- [xDS Features in gRPC](https://github.com/grpc/grpc/blob/1b31c6e0ba711787c05e8e78719896a682fca102/doc/grpc_xds_features.md)
+- [Open Request Cost Aggregation (ORCA)](https://github.com/envoyproxy/envoy/issues/6614)
+- [gRFC A14: gRPC Channelz](https://github.com/grpc/proposal/blob/6657c0723c185bda949babd120cf6e5e701cb91b/A14-channelz.md)
 - [gRFC A27: xDS-Based Global Load Balancing](https://github.com/grpc/proposal/blob/972b69ab1f0f7f6079af81a8c2b8a01a15ce3bec/A27-xds-global-load-balancing.md)
 - [gRFC A28: gRPC xDS traffic splitting and routing](https://github.com/grpc/proposal/blob/f6d38361da31ffad3158dbef84f8af3cdd89d8c1/A28-xds-traffic-splitting-and-routing.md)
 - [gRFC A29: xDS-Based Security for gRPC Clients and Servers](https://github.com/grpc/proposal/blob/deaf1bcf248d1e48e83c470b00930cbd363fab6d/A29-xds-tls-security.md)
@@ -453,7 +456,6 @@ Some troubleshooting commands:
 - [gRFC A48: xDS Least Request LB Policy](https://github.com/grpc/proposal/blob/fc4ade7b042a614aba5df8b6b82f4ca55f59a37e/A48-xds-least-request-lb-policy.md)
 - [gRFC A50: gRPC xDS Outlier Detection Support](https://github.com/grpc/proposal/blob/ee75a4010214ddda02ba992e69f1c57be7f71497/A50-xds-outlier-detection.md)
 - [gRFC A51: Custom Backend Metrics Support](https://github.com/grpc/proposal/blob/9208d9866293fcf85f2802332f34bdec106717a9/A51-custom-backend-metrics.md)
-- [Open Request Cost Aggregation (ORCA)](https://github.com/envoyproxy/envoy/issues/6614)
 - [gRFC A52: gRPC xDS Custom Load Balancer Configuration](https://github.com/grpc/proposal/blob/7c05212d14f4abef5f74f71695f95ba8dd3f7dd3/A52-xds-custom-lb-policies.md)
 - [gRFC A53: Option for Ignoring xDS Resource Deletion](https://github.com/grpc/proposal/blob/1f9b52226bf45d9f54d0eda34446b4cffabfcec6/A53-xds-ignore-resource-deletion.md)
 - [gRFC A55: xDS-Based Stateful Session Affinity for Proxyless gRPC](https://github.com/grpc/proposal/blob/9a2bd577d48b45aa9125e6a49b115690042371fe/A55-xds-stateful-session-affinity.md)

--- a/grpc-xds/control-plane-go/README.md
+++ b/grpc-xds/control-plane-go/README.md
@@ -7,9 +7,10 @@ The goal of this implementation is to provide a practical understanding of xDS,
 beyond the API specifications and the
 [pithy examples](https://github.com/grpc/grpc-go/tree/v1.59.0/examples/features/xds).
 
-This sample implementation is not recommended for production deployments, and
-there are no plans to make it production-ready. Instead, we recommend
-[Traffic Director](https://cloud.google.com/traffic-director/docs) from Google Cloud.
+This sample implementation is not recommended for production deployments.
+If you want a production-ready xDS control plane, we recommend
+[Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/service-routing/proxyless-overview)
+from Google Cloud.
 
 ## References
 

--- a/grpc-xds/control-plane-go/k8s/overlays/tls-gke-workload-certs-multi-cluster/Kustomization
+++ b/grpc-xds/control-plane-go/k8s/overlays/tls-gke-workload-certs-multi-cluster/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/control-plane-go/k8s/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/control-plane-go/k8s/overlays/tls-gke-workload-certs/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/control-plane-java/README.md
+++ b/grpc-xds/control-plane-java/README.md
@@ -7,9 +7,10 @@ The goal of this implementation is to provide a practical understanding of xDS,
 beyond the API specifications and the
 [pithy examples](https://github.com/grpc/grpc-java/tree/v1.59.0/examples/example-xds).
 
-This sample implementation is not recommended for production deployments, and
-there are no plans to make it production-ready. Instead, we recommend
-[Traffic Director](https://cloud.google.com/traffic-director/docs) from Google Cloud.
+This sample implementation is not recommended for production deployments.
+If you want a production-ready xDS control plane, we recommend
+[Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/service-routing/proxyless-overview)
+from Google Cloud.
 
 ## References
 

--- a/grpc-xds/control-plane-java/k8s/overlays/tls-gke-workload-certs-multi-cluster/Kustomization
+++ b/grpc-xds/control-plane-java/k8s/overlays/tls-gke-workload-certs-multi-cluster/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/control-plane-java/k8s/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/control-plane-java/k8s/overlays/tls-gke-workload-certs/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/docs/gke.md
+++ b/grpc-xds/docs/gke.md
@@ -380,10 +380,10 @@ or
 
 ## Workload TLS certificates using CA Service
 
-In the Traffic Director document on
-[setting up service security with proxyless gRPC](https://cloud.google.com/traffic-director/docs/security-proxyless-setup),
+In the Cloud Service Mesh document on
+[setting up service security with proxyless gRPC](https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup),
 follow the steps in the section titled
-[Create certificate authorities to issue certificates](https://cloud.google.com/traffic-director/docs/security-proxyless-setup#configure-cas)
+[Create certificate authorities to issue certificates](https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#configure-cas)
 to set up certificate authorities in CA Service to issue workload TLS
 certificates to pods on the GKE clusters.
 

--- a/grpc-xds/greeter-go/k8s/overlays/federation-gke/Kustomization
+++ b/grpc-xds/greeter-go/k8s/overlays/federation-gke/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in CA Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/greeter-go/k8s/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/greeter-go/k8s/overlays/tls-gke-workload-certs/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in CA Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/greeter-go/k8s/overlays/traffic-director/Kustomization
+++ b/grpc-xds/greeter-go/k8s/overlays/traffic-director/Kustomization
@@ -17,9 +17,9 @@
 # Deploy to a GKE cluster, with Traffic Director as the xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Traffic Director must have been set up already,
-# see: https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke-mesh
+# see: https://cloud.google.com/service-mesh/docs/service-routing/set-up-proxyless-gke-mesh
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/greeter-java/k8s/overlays/federation-gke/Kustomization
+++ b/grpc-xds/greeter-java/k8s/overlays/federation-gke/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in CA Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/greeter-java/k8s/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/greeter-java/k8s/overlays/tls-gke-workload-certs/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Requires that a certificate authority (CA) has been set up in CA Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/greeter-java/k8s/overlays/traffic-director/Kustomization
+++ b/grpc-xds/greeter-java/k8s/overlays/traffic-director/Kustomization
@@ -17,9 +17,9 @@
 # Deploy to a GKE cluster, with Traffic Director as the xDS control plane,
 # and use GKE workload TLS certificates ("mesh certificates").
 # Traffic Director must have been set up already,
-# see: https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke-mesh
+# see: https://cloud.google.com/service-mesh/docs/service-routing/set-up-proxyless-gke-mesh
 # Requires that a certificate authority (CA) has been set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/k8s/control-plane/components/tls-cert-manager/patch-cert-volume.yaml
+++ b/grpc-xds/k8s/control-plane/components/tls-cert-manager/patch-cert-volume.yaml
@@ -32,7 +32,7 @@ spec:
       - name: workload-certs
         secret:
           secretName: control-plane-certificate
-          # https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service
+          # https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service
           items:
           - key: tls.key
             path: private_key.pem

--- a/grpc-xds/k8s/control-plane/components/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/k8s/control-plane/components/tls-gke-workload-certs/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates") from Certificate Authority Service.
 # Background: https://cloud.google.com/blog/products/application-development/add-security-to-grpc-services-with-traffic-director
-# Doc: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# Doc: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 # Ref: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.MeshCertificates
 
 apiVersion: kustomize.config.k8s.io/v1alpha1

--- a/grpc-xds/k8s/control-plane/components/tls-gke-workload-certs/patch-gke-workload-certs.yaml
+++ b/grpc-xds/k8s/control-plane/components/tls-gke-workload-certs/patch-gke-workload-certs.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Patch to request GKE workload TLS certificate ("mesh certificate").
-# Ref: https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service
+# Ref: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service
 
 apiVersion: apps/v1
 kind: Deployment

--- a/grpc-xds/k8s/greeter/components/tls-cert-manager/patch-cert-volume-greeter-intermediary.yaml
+++ b/grpc-xds/k8s/greeter/components/tls-cert-manager/patch-cert-volume-greeter-intermediary.yaml
@@ -32,7 +32,7 @@ spec:
         secret:
           secretName: greeter-intermediate-cert
           items:
-          # https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service%7D
+          # https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service%7D
           - key: tls.key
             path: private_key.pem
           - key: tls.crt

--- a/grpc-xds/k8s/greeter/components/tls-cert-manager/patch-cert-volume-greeter-leaf.yaml
+++ b/grpc-xds/k8s/greeter/components/tls-cert-manager/patch-cert-volume-greeter-leaf.yaml
@@ -32,7 +32,7 @@ spec:
         secret:
           secretName: greeter-leaf-cert
           items:
-          # https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service%7D
+          # https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service%7D
           - key: tls.key
             path: private_key.pem
           - key: tls.crt

--- a/grpc-xds/k8s/greeter/components/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/k8s/greeter/components/tls-gke-workload-certs/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates") from Certificate Authority Service.
 # Background: https://cloud.google.com/blog/products/application-development/add-security-to-grpc-services-with-traffic-director
-# Doc: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# Doc: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 # Ref: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.MeshCertificates
 
 apiVersion: kustomize.config.k8s.io/v1alpha1

--- a/grpc-xds/k8s/greeter/components/tls-gke-workload-certs/patch-gke-workload-certs.yaml
+++ b/grpc-xds/k8s/greeter/components/tls-gke-workload-certs/patch-gke-workload-certs.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Patch to request GKE workload TLS certificates ("mesh certificates").
-# Ref: https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service
+# Ref: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service
 
 apiVersion: apps/v1
 kind: Deployment

--- a/grpc-xds/k8s/greeter/meta-components/tls-gke-workload-certs-federation/Kustomization
+++ b/grpc-xds/k8s/greeter/meta-components/tls-gke-workload-certs-federation/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use managed GKE workload TLS certificates ("mesh certificates").
 # A certificate authority (CA) must already be set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component

--- a/grpc-xds/k8s/greeter/meta-components/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/k8s/greeter/meta-components/tls-gke-workload-certs/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use managed GKE workload TLS certificates ("mesh certificates").
 # A certificate authority (CA) must already be set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component

--- a/grpc-xds/k8s/greeter/meta-components/traffic-director/Kustomization
+++ b/grpc-xds/k8s/greeter/meta-components/traffic-director/Kustomization
@@ -17,9 +17,9 @@
 # Deploy to a GKE cluster, use Traffic Director as the xDS control plane,
 # and use managed GKE workload TLS certificates.
 # Traffic Director must have been set up already,
-# see: https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke-mesh
+# see: https://cloud.google.com/service-mesh/docs/service-routing/set-up-proxyless-gke-mesh
 # A certificate authority (CA) must already be set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component

--- a/grpc-xds/k8s/host-certs/overlays/tls-cert-manager/patch-cert-volume-host-certs.yaml
+++ b/grpc-xds/k8s/host-certs/overlays/tls-cert-manager/patch-cert-volume-host-certs.yaml
@@ -32,7 +32,7 @@ spec:
         secret:
           secretName: host-certificate
           items:
-          # https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service%7D
+          # https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service%7D
           - key: tls.key
             path: private_key.pem
           - key: tls.crt

--- a/grpc-xds/k8s/host-certs/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/k8s/host-certs/overlays/tls-gke-workload-certs/Kustomization
@@ -16,7 +16,7 @@
 
 # Use GKE workload TLS certificates ("mesh certificates") from Certificate Authority Service.
 # Background: https://cloud.google.com/blog/products/application-development/add-security-to-grpc-services-with-traffic-director
-# Doc: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# Doc: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 # Ref: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.MeshCertificates
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/grpc-xds/k8s/troubleshoot/components/tls-cert-manager/patch-cert-volume-bastion.yaml
+++ b/grpc-xds/k8s/troubleshoot/components/tls-cert-manager/patch-cert-volume-bastion.yaml
@@ -32,7 +32,7 @@ spec:
         secret:
           secretName: bastion-certificate
           items:
-          # https://cloud.google.com/traffic-director/docs/security-proxyless-setup#create-service%7D
+          # https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#create-service%7D
           - key: tls.key
             path: private_key.pem
           - key: tls.crt

--- a/grpc-xds/k8s/troubleshoot/overlays/tls-gke-workload-certs/Kustomization
+++ b/grpc-xds/k8s/troubleshoot/overlays/tls-gke-workload-certs/Kustomization
@@ -17,7 +17,7 @@
 # Deploy to a GKE cluster, with a self-managed xDS control plane,
 # and use managed GKE workload TLS certificates ("mesh certificates").
 # A certificate authority (CA) must already be set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/grpc-xds/k8s/troubleshoot/overlays/traffic-director/Kustomization
+++ b/grpc-xds/k8s/troubleshoot/overlays/traffic-director/Kustomization
@@ -17,9 +17,9 @@
 # Deploy to a GKE cluster, use Traffic Director as the xDS control plane,
 # and use managed GKE workload TLS certificates.
 # Traffic Director must have been set up already,
-# see: https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke-mesh
+# see: https://cloud.google.com/service-mesh/docs/service-routing/set-up-proxyless-gke-mesh
 # A certificate authority (CA) must already be set up in Certificate Authority Service,
-# see: https://cloud.google.com/traffic-director/docs/security-proxyless-setup
+# see: https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Traffic Director is now Cloud Service Mesh:
https://cloud.google.com/blog/products/networking/introducing-cloud-service-mesh