### PR TITLE
docs(grpc-xds): Delete gRPC routes in cleanup

### DIFF
--- a/grpc-xds/docs/traffic-director-gke.md
+++ b/grpc-xds/docs/traffic-director-gke.md
@@ -691,6 +691,7 @@ xDS control plane.
 
     ```shell
     for app in intermediary leaf ; do
+      gcloud network-services grpc-routes delete greeter-$app --location global
       gcloud compute backend-services delete greeter-$app --global --quiet
       gcloud compute health-checks delete greeter-$app --quiet
       for region in "${REGIONS[@]}"; do


### PR DESCRIPTION
Add commands to delete the Network Services API `GRPCRoutes` as part of cleanup.

Thanks Damian!